### PR TITLE
	Added ids_to_handles(list<string> ids) return (list<Handle>);

### DIFF
--- a/handle_service.spec
+++ b/handle_service.spec
@@ -149,7 +149,9 @@ module AbstractHandle {
 		returns() authentication required;
 
 	/* Given a list of ids, this function returns
-           a list of handles.
+           a list of handles. In case of Shock, the list of ids
+           are shock node ids and this function the handles, which
+           contains Shock url and related information.
 	*/
 	funcdef ids_to_handles(list<string> ids) returns (list<Handle> handles)
 		authentication required;

--- a/lib/Bio/KBase/AbstractHandle/AbstractHandleImpl.pm
+++ b/lib/Bio/KBase/AbstractHandle/AbstractHandleImpl.pm
@@ -1634,8 +1634,8 @@ HandleId is a string
 
 =item Description
 
-The delete_handles function takes a list of handles
-and deletes them on the handle service server.
+Given a list of ids, this function returns
+a list of handles.
 
 =back
 

--- a/server-tests/id2handle.t
+++ b/server-tests/id2handle.t
@@ -1,0 +1,26 @@
+use strict;
+use Bio::KBase::AbstractHandle::AbstractHandleImpl;
+use Test::More tests => 3;
+use Data::Dumper;
+use Test::Cmd;
+use JSON;
+
+my $hsi = Bio::KBase::AbstractHandle::AbstractHandleImpl->new();
+
+ok( defined $hsi, "Check if the module is instanciated" );
+my $nhd = $hsi->new_handle("Test");
+ok( defined $nhd, "Check if the handle is instanciated" );
+$nhd = $hsi->initialize_handle($nhd);
+
+my $ahd = $hsi->ids_to_handles([$nhd->{id}]);
+$ahd = $$ahd[0];
+my $json = JSON->new();
+$json = $json->canonical([]);
+
+$ahd->{creation_date} = undef;
+my %nhd = map { $_ => $nhd->{$_} } grep (defined $nhd->{$_}, sort keys %$nhd);
+my %ahd = map { $_ => $ahd->{$_} } grep (defined $ahd->{$_}, sort keys %$ahd);
+my $nhs = $json->encode(\%nhd);
+my $ahs = $json->encode(\%ahd);
+
+ok($nhs eq $ahs, "Check whether the same handle or not" );

--- a/server-tests/scratch.sh
+++ b/server-tests/scratch.sh
@@ -16,3 +16,4 @@ perl -e 'use Data::Dumper; use Bio::KBase::AbstractHandle::AbstractHandleImpl; $
 # echo "does initialize_handle() work"
 perl -e 'use Data::Dumper; use Bio::KBase::AbstractHandle::AbstractHandleImpl; $dsi=Bio::KBase::AbstractHandle::AbstractHandleImpl->new(); print Dumper $dsi->initialize_handle($dsi->new_handle());'
 
+perl id2handle.t


### PR DESCRIPTION
To support transforms service, we need a function that returns handles given shock node ids.
