### PR TITLE
Added code to make __init__.py, so python client libraries work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,6 +315,8 @@ compile-docs: build-libs
 # target depends on the compiled libs.
 
 build-libs:
+	touch lib/biokbase/__init__.py #do not include code in biokbase/__init__.py
+	touch lib/biokbase/$(SERVICE_NAME)/__init__.py
 	compile_typespec \
 		--psgi $(SERVICE_PSGI)  \
 		--impl Bio::KBase::$(SERVICE_NAME)::$(SERVICE_NAME)Impl \

--- a/Makefile
+++ b/Makefile
@@ -315,8 +315,6 @@ compile-docs: build-libs
 # target depends on the compiled libs.
 
 build-libs:
-	touch lib/biokbase/__init__.py #do not include code in biokbase/__init__.py
-	touch lib/biokbase/$(SERVICE_NAME)/__init__.py
 	compile_typespec \
 		--psgi $(SERVICE_PSGI)  \
 		--impl Bio::KBase::$(SERVICE_NAME)::$(SERVICE_NAME)Impl \
@@ -326,6 +324,8 @@ build-libs:
 		--js javascript/$(SERVICE_NAME)/Client \
 		--url $(SELF_URL) \
 		$(SERVICE_SPEC) lib
+	touch lib/biokbase/__init__.py #do not include code in biokbase/__init__.py
+	touch lib/biokbase/$(SERVICE_NAME)/__init__.py
 
 # the Makefile.common.rules contains a set of rules that can be used
 # in this setup. Because it is included last, it has the effect of


### PR DESCRIPTION
If __init__.py is not created in /kb/deployment/lib/biokbase/AbstractHandle/, python will complain about not being able to find the library when you try to import it.