### PR TITLE
TASK-1203 Made handle-namespace an option in deployment config file.

### DIFF
--- a/deploy.cfg
+++ b/deploy.cfg
@@ -5,8 +5,11 @@
 self-url =
 service-port = 7109
 service-host = localhost
-default-shock-server = http://140.221.85.86:7078
-auth-service-url = https://kbase.us/services/authorization/Sessions/Login
+default-shock-server = http://localhost:7044
+auth-service-url=https://kbase.us/services/auth/api/legacy/KBase/Sessions/Login
+# this is used as a prefix for handles (e.g., HSI_1)
+# DO NOT CHANGE THIS once any handles have been saved
+handle-namespace = HSI
 
 # mysql database configs
 mysql-host  = localhost

--- a/deployment/conf/.templates/deployment.cfg.j2
+++ b/deployment/conf/.templates/deployment.cfg.j2
@@ -8,6 +8,6 @@ mlog_log_level={{ mlog_log_level|default('6') }}
 mysql-pass={{ mysql_pass|default('') }}
 mysql-perm={{ mysql_perm|default('ALL') }}
 default-shock-server={{ default_shock_server|default('https://ci.kbase.us/services/shock-api/') }}
+handle-namespace={{ handle_namespace|default('KBH') }}
 service-port={{ service_port|default('7109') }}
-# The KBase authorization server url.
 auth-service-url={{ auth_service_url|default('https://ci.kbase.us/services/auth/api/legacy/KBase/Sessions/Login') }}

--- a/lib/Bio/KBase/AbstractHandle/AbstractHandleImpl.pm
+++ b/lib/Bio/KBase/AbstractHandle/AbstractHandleImpl.pm
@@ -32,7 +32,7 @@ Log::Log4perl->easy_init($DEBUG);
 use Bio::KBase::HandleServiceConstants 'handleNameSpace';
 
 our $namespace = handleNameSpace;
-INFO "using $namespace as the namespace for handles created by this service";
+INFO "pid $$ using $namespace as the default handle namespace";
 
 our $cfg = {};
 our ($default_shock, $mysql_host, $mysql_port, $mysql_user, $mysql_pass,
@@ -42,16 +42,23 @@ if (defined $ENV{KB_DEPLOYMENT_CONFIG} && -e $ENV{KB_DEPLOYMENT_CONFIG}) {
     $cfg = new Config::Simple($ENV{KB_DEPLOYMENT_CONFIG}) or
         die "could not construct new Config::Simple object";
     $default_shock = $cfg->param('handle_service.default-shock-server');
+    $namespace     = $cfg->param('handle_service.handle-namespace');
     $mysql_host    = $cfg->param('handle_service.mysql-host');
     $mysql_port    = $cfg->param('handle_service.mysql-port');
     $mysql_user    = $cfg->param('handle_service.mysql-user');
     $mysql_pass    = $cfg->param('handle_service.mysql-pass');
     $data_source   = $cfg->param('handle_service.data-source');
-    INFO "$$ reading config from $ENV{KB_DEPLOYMENT_CONFIG}";
-    INFO "$$ using $default_shock as the default shock server";
+    INFO "pid $$ reading config from $ENV{KB_DEPLOYMENT_CONFIG}";
+    INFO "pid $$ using $default_shock as the default shock server";
+    INFO "pid $$ using $namespace as the namespace for handles created by this service";
 }
 else {
-    die "could not find KB_DEPLOYMENT_CONFIG";
+    die "pid $$ CRITICAL: could not find KB_DEPLOYMENT_CONFIG, exiting";
+}
+
+unless ($namespace)
+{
+    die "pid $$ CRITICAL: handle namespace was not set, exiting";
 }
 
 # methods not exposed in the API


### PR DESCRIPTION
Please review carefully before merging!  No tests, so first real test will be live on CI.

Make the namespace variable a configurable option in the config file.  Set the default namespace in the various repo config files (a dummy value in deploy.cfg; a real value in the Jinja template).